### PR TITLE
Add macOS builder for GH Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -2,7 +2,7 @@ name: Build Workflow
 
 on:
   push:
-       branches: main
+    branches: main
 
 jobs:
   build-windows:
@@ -25,3 +25,23 @@ jobs:
         with:
           name: DeepLabCut-Display
           path: dist/DeepLabCut-Display.exe
+  build-macos:
+    runs-on: macos-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Install Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.11'
+          architecture: 'arm64'
+      - name: Install requirements
+        run: |
+          pip install -r requirements.txt
+      - name: Run PyInstaller
+        run: |
+          python -m PyInstaller mainGUI.spec
+      - uses: actions/upload-artifact@v3
+        with:
+          name: DeepLabCut-Display-macOS
+          path: dist/DeepLabCut-Display


### PR DESCRIPTION
Added a GitHub build action for automatically creating a macOS-friendly executable. Similar to the existing build action for creating a Windows executable, this new action uses the same "something was committed to main" trigger and builds on a free-tier macOS runner, creating a `DeepLabCut-Display-macOS` artifact which will run on modern Mac hardware that uses a M1/M2/M3-processor. This new action tested fine in my fork of this repo, and the resulting artifact I was able to download to a M1 MacBookAir and run it fine (example run [here](https://github.com/pbarry25/DeepLabCut-Display/actions/runs/10984945129)).

<img width="796" alt="Screenshot 2024-09-22 at 4 13 56 PM" src="https://github.com/user-attachments/assets/bef46ecc-894a-493c-8682-382166ec8d1b">